### PR TITLE
Check if current directory is in a git repo

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,14 @@ import clipboard from "clipboardy";
 
 const CONVENTIONAL_REQUEST = `following conventional commit (<type>: <subject>)`;
 
+try {
+  execSync("git rev-parse --is-inside-work-tree 2>/dev/null");
+} catch (e) {
+  console.log("This is not a git repository.");
+  process.exit(1);
+}
+
+
 let diff = "";
 try {
   diff = execSync("git diff --cached").toString();


### PR DESCRIPTION
Add a check to see if the current directory is a git repo, before executing `git-diff` to prevent it from printing the help message.